### PR TITLE
feat: local 환경 MySQL 연동 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.env
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,16 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // DB
+    implementation 'com.mysql:mysql-connector-j'
+
+    // TEST DB
+    implementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: "jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT:3306}/${DATABASE_NAME}"
+    username: "${DATABASE_USERNAME}"
+    password: "${DATABASE_PASSWORD}"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,9 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=keun-sori-server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   application:
     name: keun-sori-server
+  profiles:
+    group:
+      local: "local,datasource"
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: keun-sori-server


### PR DESCRIPTION
## 작업 내용
- local 프로파일에서 mysql 연동 설정을 추가하였습니다.
- 

## 특이 사항 (리뷰 시 참고할 내용)
- 데이터베이스는 로컬에 설치한 데이터베이스를 활용하는데, 스키마(데이터베이스)는 미리 만들어둬야 합니다. (테이블은 JPA로 생성)
- username, password 는 각자 자신의 것을 활용해야 하다보니 `.env` 파일로 외부에서 입력받도록 했습니다.
(설정하는 방법은 노션에 따로 추가해둘게요!)
- host, database name 도 하드코딩해두기 보다는 외부에서 넣어주도록 환경변수로 뺐습니다!
- 로컬에서 실행 전에 profile 을 local 로 설정해야 합니다!


### 관련 이슈
close #3 
