### PR TITLE
refactor: 다른 세션의 경우 같은 시간대 예약이 가능하도록 수정

### DIFF
--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/dto/requset/ReservationCreateRequest.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/dto/requset/ReservationCreateRequest.java
@@ -19,15 +19,16 @@ public record ReservationCreateRequest(
         String reservationSession,
         @Schema(example = "2025-01-01", type = "string")
         LocalDate reservationDate,
-        @Schema(example = "21:00", type = "string")
+        @Schema(example = "20:00", type = "string")
         LocalTime reservationStartTime,
         @Schema(example = "21:00", type = "string")
         LocalTime reservationEndTime
 ) {
     public Reservation toEntity(Member member) {
+        ReservationType reservationType = ReservationType.from(reservationType());
         return Reservation.builder()
-                .reservationType(ReservationType.from(reservationType))
-                .session(Session.from(reservationSession))
+                .reservationType(reservationType)
+                .session(reservationType.equals(ReservationType.TEAM) ? Session.ALL : Session.from(reservationSession))
                 .date(reservationDate)
                 .startTime(reservationStartTime)
                 .endTime(reservationEndTime)

--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.keunsori.keunsoriserver.domain.member.domain.Member;
 import com.keunsori.keunsoriserver.domain.reservation.domain.Reservation;
+import com.keunsori.keunsoriserver.domain.reservation.domain.vo.Session;
 
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -31,4 +32,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Reservation r SET r.member = null WHERE r.member.id = :memberId")
     void unlinkMember(Long memberId);
+
+    @Query("SELECT COUNT(r) > 0 "
+         + "FROM Reservation r "
+         + "WHERE r.date = :date "
+         + "AND (r.session = :session OR r.reservationType = 'TEAM') "
+         + "AND (r.startTime BETWEEN :start_time AND :end_time "
+         + "OR   r.endTime BETWEEN :start_time AND :end_time "
+         + "OR   :start_time BETWEEN r.startTime AND r.endTime)")
+    boolean existsAnotherReservationAtDateAndTimePeriodWithSession(@Param("date") LocalDate date, @Param("session") Session session, @Param("start_time") LocalTime startTime, @Param("end_time") LocalTime endTime);
 }

--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/service/ReservationService.java
@@ -42,9 +42,9 @@ public class ReservationService {
     public Long createReservation(ReservationCreateRequest request) {
         Member member = memberUtil.getLoggedInMember();
 
-        reservationValidator.validateReservationCreateForm(request);
-
+        reservationValidator.validateReservationFromCreateRequest(request);
         Reservation reservation = request.toEntity(member);
+
         reservationRepository.save(reservation);
         return reservation.getId();
     }
@@ -65,8 +65,8 @@ public class ReservationService {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationException(RESERVATION_NOT_EXISTS_WITH_ID));
 
-        reservationValidator.validateReservationUpdateForm(request);
-        reservationValidator.validateReservationUpdatable(reservation, member);
+        reservationValidator.validateReservationFromUpdateRequest(request);
+        reservationValidator.validateOriginalReservationUpdatable(reservation, member);
 
         reservation.updateReservation(
                 ReservationType.from(request.reservationSession()),

--- a/src/main/java/com/keunsori/keunsoriserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/exception/ErrorMessage.java
@@ -11,6 +11,8 @@ public class ErrorMessage {
     public static final String RESERVATION_NOT_EXISTS_WITH_ID = "해당 아이디 값을 가진 예약이 존재하지 않습니다.";
     public static final String RESERVATION_NOT_EQUAL_MEMBER = "예약한 멤버가 아닙니다.";
     public static final String RESERVATION_ALREADY_COMPLETED = "확정된 예약은 수정/취소할 수 없습니다.";
-    public static final String ANOTHER_RESERVATION_EXISTS = "해당 시간대에 다른 예약이 존재합니다.";
+    public static final String ANOTHER_RESERVATION_ALREADY_EXISTS = "해당 시간대에 다른 예약이 존재합니다.";
     public static final String INVALID_RESERVATION_TIME = "예약 종료 시간은 예약 시작 시간보다 나중이어야 합니다.";
+    public static final String INVALID_RESERVATION_TYPE = "예약 타입이 잘못되었습니다.";
+    public static final String INVALID_RESERVATION_DATE = "예약 날짜는 과거 날짜면 안됩니다.";
 }

--- a/src/test/java/com/keunsori/keunsoriserver/common/ApiTest.java
+++ b/src/test/java/com/keunsori/keunsoriserver/common/ApiTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,8 +28,8 @@ public class ApiTest {
 
     protected String token;
 
-    @BeforeEach
-    public void setUp() {
+    @AfterEach
+    public void clear() {
         dataCleaner.clear();
     }
 

--- a/src/test/java/com/keunsori/keunsoriserver/reservation/api/ReservationApiTest.java
+++ b/src/test/java/com/keunsori/keunsoriserver/reservation/api/ReservationApiTest.java
@@ -1,10 +1,9 @@
 package com.keunsori.keunsoriserver.reservation.api;
 
-import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.ANOTHER_RESERVATION_EXISTS;
+import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.ANOTHER_RESERVATION_ALREADY_EXISTS;
 import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.INVALID_RESERVATION_TIME;
 import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.RESERVATION_ALREADY_COMPLETED;
 import static io.restassured.RestAssured.given;
-import static org.mockito.Mockito.mockStatic;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpHeaders.LOCATION;
@@ -16,8 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import org.springframework.test.context.jdbc.Sql;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.keunsori.keunsoriserver.common.ApiTest;
@@ -48,11 +46,31 @@ public class ReservationApiTest extends ApiTest {
     }
 
     @Test
-    void 예약_생성에_성공한다() throws JsonProcessingException {
+    void 개인_예약_생성에_성공한다() throws JsonProcessingException {
         ReservationCreateRequest request = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
-                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2999, 1, 1),
+                LocalTime.of(12, 0),
+                LocalTime.of(14, 0)
+        );
+
+        given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request)).
+        when().
+                post("/reservation").
+        then().
+                statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Test
+    void 팀_예약_생성에_성공한다() throws JsonProcessingException {
+        ReservationCreateRequest request = new ReservationCreateRequest(
+                "TEAM",
+                "ALL",
+                LocalDate.of(2999, 1, 1),
                 LocalTime.of(12, 0),
                 LocalTime.of(14, 0)
         );
@@ -72,7 +90,7 @@ public class ReservationApiTest extends ApiTest {
         ReservationCreateRequest request = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
-                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2999, 1, 1),
                 LocalTime.of(14, 0),
                 LocalTime.of(12, 0)
         );
@@ -97,7 +115,7 @@ public class ReservationApiTest extends ApiTest {
         ReservationCreateRequest request = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
-                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2999, 1, 1),
                 LocalTime.of(12, 0),
                 LocalTime.of(12, 0)
         );
@@ -117,7 +135,7 @@ public class ReservationApiTest extends ApiTest {
         Assertions.assertThat(errorMessage).isEqualTo(INVALID_RESERVATION_TIME);
     }
 
-    static Stream<Arguments> failedReservationTimeTestData() {
+    static Stream<Arguments> overlapReservationTimeTestData() {
         return Stream.of(
                 Arguments.arguments(LocalTime.of(12, 0), LocalTime.of(14, 0)),
                 Arguments.arguments(LocalTime.of(13, 0), LocalTime.of(14, 0)),
@@ -128,12 +146,12 @@ public class ReservationApiTest extends ApiTest {
     }
 
     @ParameterizedTest
-    @MethodSource("failedReservationTimeTestData")
-    void 예약_시간이_다른_예약과_겹치면_예약에_실패한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
+    @MethodSource("overlapReservationTimeTestData")
+    void 세션이_같으면_예약_시간이_다른_예약과_겹칠_때_예약에_실패한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
         ReservationCreateRequest request1 = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
-                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2999, 1, 1),
                 LocalTime.of(12, 0),
                 LocalTime.of(14, 0)
         );
@@ -141,7 +159,7 @@ public class ReservationApiTest extends ApiTest {
         ReservationCreateRequest request2 = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
-                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2999, 1, 1),
                 startTime,
                 endTime
         );
@@ -167,31 +185,24 @@ public class ReservationApiTest extends ApiTest {
                 extract().
                 jsonPath().get("message");
 
-        Assertions.assertThat(errorMessage).isEqualTo(ANOTHER_RESERVATION_EXISTS);
-    }
-
-    static Stream<Arguments> successReservationTimeTestData() {
-        return Stream.of(
-                Arguments.arguments(LocalTime.of(11, 0), LocalTime.of(12, 0)),
-                Arguments.arguments(LocalTime.of(14, 0), LocalTime.of(15, 0))
-        );
+        Assertions.assertThat(errorMessage).isEqualTo(ANOTHER_RESERVATION_ALREADY_EXISTS);
     }
 
     @ParameterizedTest
-    @MethodSource("successReservationTimeTestData")
-    void 예약_시간이_경계에_걸쳐도_성공한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
+    @MethodSource("overlapReservationTimeTestData")
+    void 세션이_다르면_예약_시간이_겹쳐도_성공한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
         ReservationCreateRequest request1 = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
-                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2999, 1, 1),
                 LocalTime.of(12, 0),
                 LocalTime.of(14, 0)
         );
 
         ReservationCreateRequest request2 = new ReservationCreateRequest(
                 "PERSONAL",
-                "DRUM",
-                LocalDate.of(2025, 1, 1),
+                "GUITAR",
+                LocalDate.of(2999, 1, 1),
                 startTime,
                 endTime
         );
@@ -215,8 +226,134 @@ public class ReservationApiTest extends ApiTest {
                 statusCode(HttpStatus.SC_CREATED);
     }
 
+    @ParameterizedTest
+    @MethodSource("overlapReservationTimeTestData")
+    void 팀_예약이_존재하면_개인_예약의_예약_시간이_겹쳤을_때_실패한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
+        ReservationCreateRequest request1 = new ReservationCreateRequest(
+                "TEAM",
+                "ALL",
+                LocalDate.of(2999, 1, 1),
+                LocalTime.of(12, 0),
+                LocalTime.of(14, 0)
+        );
+
+        ReservationCreateRequest request2 = new ReservationCreateRequest(
+                "PERSONAL",
+                "GUITAR",
+                LocalDate.of(2999, 1, 1),
+                startTime,
+                endTime
+        );
+
+        given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request1)).
+        when().
+                post("/reservation").
+        then().
+                statusCode(HttpStatus.SC_CREATED);
+
+        given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request2)).
+        when().
+                post("/reservation").
+        then().
+                statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @ParameterizedTest
+    @MethodSource("overlapReservationTimeTestData")
+    void 팀_예약은_예약_시간이_다른_예약과_겹칠_때_예약에_실패한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
+        ReservationCreateRequest request1 = new ReservationCreateRequest(
+                "PERSONAL",
+                "DRUM",
+                LocalDate.of(2999, 1, 1),
+                LocalTime.of(12, 0),
+                LocalTime.of(14, 0)
+        );
+
+        ReservationCreateRequest request2 = new ReservationCreateRequest(
+                "TEAM",
+                "ALL",
+                LocalDate.of(2999, 1, 1),
+                startTime,
+                endTime
+        );
+
+        given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request1)).
+        when().
+                post("/reservation").
+        then().
+                statusCode(HttpStatus.SC_CREATED);
+
+        String errorMessage =
+                given().
+                        header(AUTHORIZATION, authorizationValue).
+                        header(CONTENT_TYPE, "application/json").
+                        body(mapper.writeValueAsString(request2)).
+                when().
+                        post("/reservation").
+                then().
+                        statusCode(HttpStatus.SC_BAD_REQUEST).
+                        extract().
+                        jsonPath().get("message");
+
+        Assertions.assertThat(errorMessage).isEqualTo(ANOTHER_RESERVATION_ALREADY_EXISTS);
+    }
+
+    static Stream<Arguments> successReservationTimeTestData() {
+        return Stream.of(
+                Arguments.arguments(LocalTime.of(11, 0), LocalTime.of(12, 0)),
+                Arguments.arguments(LocalTime.of(14, 0), LocalTime.of(15, 0))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("successReservationTimeTestData")
+    void 예약_시간이_경계에_걸쳐도_성공한다(LocalTime startTime, LocalTime endTime) throws JsonProcessingException {
+        ReservationCreateRequest request1 = new ReservationCreateRequest(
+                "PERSONAL",
+                "DRUM",
+                LocalDate.of(2999, 1, 1),
+                LocalTime.of(12, 0),
+                LocalTime.of(14, 0)
+        );
+
+        ReservationCreateRequest request2 = new ReservationCreateRequest(
+                "PERSONAL",
+                "DRUM",
+                LocalDate.of(2999, 1, 1),
+                startTime,
+                endTime
+        );
+
+        given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request1)).
+        when().
+                post("/reservation").
+        then().
+                statusCode(HttpStatus.SC_CREATED);
+
+        given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request2)).
+        when().
+                post("/reservation").
+        then().
+                statusCode(HttpStatus.SC_CREATED);
+    }
+
     @Test
-    void 예약_취소에_성공한다() throws JsonProcessingException {
+    void 일반_유저가_자신의_예약_취소에_성공한다() throws JsonProcessingException {
         ReservationCreateRequest request = new ReservationCreateRequest(
                 "PERSONAL",
                 "DRUM",
@@ -237,8 +374,6 @@ public class ReservationApiTest extends ApiTest {
                     extract().
                     header(LOCATION);
 
-        System.out.println(reservationLocation);
-
         given().
                 header(AUTHORIZATION, authorizationValue).
                 header(CONTENT_TYPE, "application/json").
@@ -250,35 +385,13 @@ public class ReservationApiTest extends ApiTest {
     }
 
     @Test
+    @Sql(statements = "INSERT INTO reservation (reservation_id, reservation_date, reservation_end_time, reservation_type, reservation_session, reservation_start_time, member_id) VALUES (1, '2025-01-01', '22:00:00', 'PERSONAL', 'VOCAL', '21:00:00', 1);")
     void 예약_시간을_넘어간_예약은_확정되어_예약_취소에_실패한다() throws JsonProcessingException {
-        ReservationCreateRequest request = new ReservationCreateRequest(
-                "PERSONAL",
-                "DRUM",
-                LocalDate.of(2025, 1, 29),
-                LocalTime.of(12, 0),
-                LocalTime.of(14, 0)
-        );
-
-        String reservationLocation =
-                given().
-                        header(AUTHORIZATION, authorizationValue).
-                        header(CONTENT_TYPE, "application/json").
-                        body(mapper.writeValueAsString(request)).
-                when().
-                        post("/reservation").
-                then().
-                        statusCode(HttpStatus.SC_CREATED).
-                        extract().
-                        header(LOCATION);
-
-
         String errorMessage =
                 given().
                         header(AUTHORIZATION, authorizationValue).
-                        header(CONTENT_TYPE, "application/json").
-                        body(mapper.writeValueAsString(request)).
                 when().
-                        delete(reservationLocation).
+                        delete("/reservation/1").
                 then().
                         statusCode(HttpStatus.SC_BAD_REQUEST).
                         extract().

--- a/src/test/resources/import.sql
+++ b/src/test/resources/import.sql
@@ -1,7 +1,7 @@
 INSERT INTO member (member_id, create_date, update_date, approval_date, hongikgmail, name, password, status, student_id) VALUES (1, '2025-01-24 17:13:21.229103', '2025-01-24 17:13:21.229103', null, 'hello@g.hongik.ac.kr', '권찬', '$2a$10$dwQMaJPc5PKzS6w4I8Wi..DAYEkOKb7PSoeF9gplcfDzMWcC2k2eq', '일반', 'C011013');
 INSERT INTO member (member_id, create_date, update_date, approval_date, hongikgmail, name, password, status, student_id) VALUES (2, '2025-01-25 03:16:36.414396', '2025-01-25 03:16:36.414396', null, 'hello2@g.hongik.ac.kr', '권찬', '$2a$10$ED7kelp/IBsvNtvHVv/CfeWtQN.vymhDfTPYD50jKYvmxXn5c87im', '일반', 'C011014');
-INSERT INTO member (member_id, create_date, update_date, approval_date, hongikgmail, name, password, status, student_id) VALUES (3, '2025-01-25 13:31:43.977683', '2025-01-25 13:31:43.977683', null, 'admin@g.hongik.ac.kr', '관리자', '$2a$10$RktScSKj4H0X1xosTHk5r.oOTJS0ZKXDeLJDqJBLikosQnQ1Mwste', '관리자', 'C011000');
+INSERT INTO member (member_id, create_date, update_date, approval_date, hongikgmail, name, password, status, student_id) VALUES (3, '2025-01-25 13:31:43.977683', '2025-01-25 13:31:43.977683', null, 'admin@g.hongik.ac.kr', '관리자', '$2a$10$XyBz6shlUlVC7HiKckWHX.wsstjTy19Y239VuK.wuZXwdDLH4lDHy', '관리자', 'Z011000');
 
 
--- INSERT INTO reservation (reservation_id, reservation_date, reservation_end_time, reservation_type, reservation_session, reservation_start_time, member_id) VALUES (1, '2025-01-01', '22:00:00', 'TEAM', 'VOCAL', '21:00:00', 1);
--- INSERT INTO reservation (reservation_id, reservation_date, reservation_end_time, reservation_type, reservation_session, reservation_start_time, member_id) VALUES (2, '2025-01-01', '23:00:00', 'TEAM', 'VOCAL', '22:00:00', 1);
+# INSERT INTO reservation (reservation_id, reservation_date, reservation_end_time, reservation_type, reservation_session, reservation_start_time, member_id) VALUES (1, '2025-01-01', '22:00:00', 'PERSONAL', 'VOCAL', '21:00:00', 1);
+# INSERT INTO reservation (reservation_id, reservation_date, reservation_end_time, reservation_type, reservation_session, reservation_start_time, member_id) VALUES (2, '2025-01-01', '23:00:00', 'TEAM', 'VOCAL', '22:00:00', 1);


### PR DESCRIPTION
## 작업 내용
- 개인 예약할 때 세션이 다르면 시간대가 겹쳐도 괜찮도록 수정했습니다.
- 예약 취소할 때 어드민 무조건 허용하는 코드 제거했습니다.
- 팀 에약 생성시 자동으로 세션은 ALL 지정되도록 했습니다.
- 예약 신청 날짜는 과거 날짜가 될 수 없도록 조건을 걸었습니다.

## 특이 사항 (리뷰 시 참고할 내용)
- 

### 관련 이슈
close #31 
