### PR TITLE
fix: 삭제된 회원의 예약정보를 올바르게 가져오도록 개선

### DIFF
--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/domain/Reservation.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/domain/Reservation.java
@@ -11,8 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
-import org.springframework.cglib.core.Local;
-
 import com.keunsori.keunsoriserver.domain.member.domain.Member;
 import com.keunsori.keunsoriserver.domain.reservation.domain.vo.ReservationType;
 import com.keunsori.keunsoriserver.domain.reservation.domain.vo.Session;
@@ -88,5 +86,19 @@ public class Reservation {
         // TODO : new Date 호출 시점을 컨트롤러 호출 시점과 맞추기
         // TODO : LocalDate 테스트가 가능하도록 분리하기
         return LocalDate.now().isAfter(date);
+    }
+
+    public Long getMemberId() {
+        if (member == null) {
+            return null;
+        }
+        return member.getId();
+    }
+
+    public String getMemberName() {
+        if (member == null) {
+            return "(알 수 없음)";
+        }
+        return member.getName();
     }
 }

--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/dto/response/ReservationResponse.java
@@ -25,8 +25,8 @@ public record ReservationResponse(
                 reservation.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")),
                 reservation.getEndTime().format(DateTimeFormatter.ofPattern("HH:mm")),
                 reservation.getReservationType(),
-                reservation.getMember().getId(),
-                reservation.getMember().getName()
+                reservation.getMemberId(),
+                reservation.getMemberName()
         );
     }
 }

--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/repository/ReservationRepository.java
@@ -35,7 +35,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     // 탈퇴된 회원 외래키 null 처리 쿼리
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Reservation r SET r.member = null WHERE r.member.id = :memberId")
-    void unlinkMember(Long memberId);
+    void unlinkMember(@Param("memberId") Long memberId);
 
     @Query("SELECT COUNT(r) > 0 "
          + "FROM Reservation r "

--- a/src/main/java/com/keunsori/keunsoriserver/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/reservation/service/ReservationService.java
@@ -2,8 +2,6 @@ package com.keunsori.keunsoriserver.domain.reservation.service;
 
 import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.RESERVATION_NOT_EXISTS_WITH_ID;
 
-import com.keunsori.keunsoriserver.domain.admin.reservation.repository.DailyScheduleRepository;
-import com.keunsori.keunsoriserver.domain.admin.reservation.repository.WeeklyScheduleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
## 작업 내용
- 탈퇴한 회원의 예약 정보를 가져오도록 수정했습니다
- 회원 탈퇴 시 예약에서 연관관계를 끊어내는 SQL 파라미터를 명시적으로 넘기도록 수정하였습니다

## 특이 사항 (리뷰 시 참고할 내용)
- 

### 관련 이슈
close #47 
