### PR TITLE
fix: 예약 가능 시간표 두달치 보내도록 수정

### DIFF
--- a/src/main/java/com/keunsori/keunsoriserver/domain/admin/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/admin/reservation/controller/AdminReservationController.java
@@ -35,7 +35,7 @@ public class AdminReservationController {
 
     // 일자별 관리 페이지 반환
     @GetMapping("/daily-schedule")
-    public ResponseEntity<List<DailyAvailableResponse>> findAllDailySchedulesAndResrvations(@RequestParam("month") String month) {
+    public ResponseEntity<List<DailyAvailableResponse>> findAllDailySchedulesAndReservations(@RequestParam("month") String month) {
         List<DailyAvailableResponse> responses = adminReservationService.findDailyAvailableByMonth(month);
         return ResponseEntity.ok().body(responses);
     }

--- a/src/main/java/com/keunsori/keunsoriserver/domain/admin/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/admin/reservation/service/AdminReservationService.java
@@ -92,7 +92,7 @@ public class AdminReservationService {
     public List<DailyAvailableResponse> findDailyAvailableByMonth(String yearMonth) {
 
         LocalDate start = DateUtil.parseMonthToFirstDate(yearMonth);
-        LocalDate end = start.plusMonths(1);
+        LocalDate end = start.plusMonths(2);
 
         return Stream.iterate(start, date -> date.isBefore(end), date -> date.plusDays(1))
                 .map(this::convertDateToDailyAvailableResponse).toList();


### PR DESCRIPTION
## 작업 내용
- 예약 가능 시간표를 두달치를 한번에 보내줘야 프론트에서 다음달 예약 안되는 시간 막게 적용이 된다 해서 핫픽스로 올렸습니다!

## 특이 사항 (리뷰 시 참고할 내용)
- 핫픽스긴 한데 진짜 곧바로 적용해야 할만큼 급한거 같진 않아서 승인 받고 올리겠습니다! 주관적 판단이라 급하다고 생각하시면 말해주세여
- 이거 메인에 적용하고 디벨롭에도 적용할 때는 어떻게 올려야 하나요...

### 관련 이슈
close #76
