### PR TITLE
refactor: httpOnly Cookie 방식으로 로그인 로직 수정

### DIFF
--- a/src/main/java/com/keunsori/keunsoriserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/auth/controller/AuthController.java
@@ -1,79 +1,55 @@
 package com.keunsori.keunsoriserver.domain.auth.controller;
 
-import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.INVALID_REFRESH_TOKEN;
-import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.MEMBER_NOT_EXISTS_WITH_STUDENT_ID;
-
-import com.keunsori.keunsoriserver.domain.auth.login.LoginService;
 import com.keunsori.keunsoriserver.domain.auth.login.dto.request.LoginRequest;
-import com.keunsori.keunsoriserver.domain.auth.redis.RefreshTokenService;
-import com.keunsori.keunsoriserver.domain.auth.login.JwtTokenManager;
-import com.keunsori.keunsoriserver.domain.auth.login.dto.response.LoginResponse;
+import com.keunsori.keunsoriserver.domain.auth.service.AuthService;
+import com.keunsori.keunsoriserver.domain.auth.service.TokenService;
 import com.keunsori.keunsoriserver.domain.member.domain.Member;
 import com.keunsori.keunsoriserver.domain.member.repository.MemberRepository;
-import com.keunsori.keunsoriserver.global.exception.AuthException;
 import com.keunsori.keunsoriserver.global.exception.MemberException;
 
+
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.*;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final LoginService loginService;
-    private final JwtTokenManager jwtTokenManager;
-    private final RefreshTokenService authService;
+    private final AuthService authService;
     private final MemberRepository memberRepository;
+    private final TokenService tokenService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest)  {
-        LoginResponse loginResponse = loginService.login(loginRequest);
-        return ResponseEntity.ok(loginResponse);
+    public ResponseEntity<Void> lgoin(@Valid @RequestBody LoginRequest loginRequest, HttpServletResponse response){
+        Member member = memberRepository.findByStudentIdIgnoreCase(loginRequest.studentId())
+                .orElseThrow(()->new MemberException(STUDENT_ID_NOT_EXISTS));
+
+        authService.login(member, response);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<LoginResponse> reissue(@RequestHeader("Refresh-Token") String refreshToken){
-        //Refresh Token에서 studentId 뽑아내기
-        String studentId = jwtTokenManager.getStudentIdFromToken(refreshToken);
-
-        Member member = memberRepository.findByStudentId(studentId)
-                .orElseThrow(() -> new MemberException(MEMBER_NOT_EXISTS_WITH_STUDENT_ID));
-
-        //Redis에 저장된 Refresh Token과 일치하는지 확인
-        String storedRefreshToken = authService.getRefreshToken(studentId);
-        if(storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
-            throw new AuthException(INVALID_REFRESH_TOKEN);
-        }
-
-        //새로운 AccessToken 생성
-        String newAccessToken = jwtTokenManager.generateAccessToken(studentId, member.getName(), member.getStatus());
-
-        //새로운 Acess Token 반환
-        return ResponseEntity.ok(new LoginResponse(
-                newAccessToken,
-                refreshToken,
-                String.valueOf(jwtTokenManager.getExpirationTime(newAccessToken)),
-                member.getName(),
-                member.getStatus()
-        ));
+    public ResponseEntity<String> reissue(@CookieValue(value = "Refresh-Token", required = false) String refreshToken, HttpServletResponse response){
+        authService.reissueToken(refreshToken, response);
+        return ResponseEntity.ok("토큰 재발급 성공");
     }
     //로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@RequestHeader("Authorization") String accessToken){
-        String studentId= jwtTokenManager.getStudentIdFromToken(accessToken);
-
-        authService.deleteRefreshToken(studentId);
-
-        return ResponseEntity.ok("로그아웃 됐습니다.");
+    public ResponseEntity<String> logout(@CookieValue(value = "Refresh-Token", required = false) String refreshToken, HttpServletResponse response){
+        authService.logout(refreshToken, response);
+        return ResponseEntity.ok("로그아웃 성공");
     }
 
     //Access Token 유효성 검사(보안 강화)
     @GetMapping("/validate")
     public ResponseEntity<String> validateToken(@RequestHeader("Authorization") String accessToken){
-        boolean isValid= jwtTokenManager.validateToken(accessToken);
+        boolean isValid= tokenService.validateToken(accessToken);
 
         if(isValid){
             return ResponseEntity.ok("Access Token 유효.");

--- a/src/main/java/com/keunsori/keunsoriserver/domain/auth/login/LoginService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/auth/login/LoginService.java
@@ -6,6 +6,7 @@ import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.STUDENT_
 import com.keunsori.keunsoriserver.domain.auth.login.dto.request.LoginRequest;
 import com.keunsori.keunsoriserver.domain.auth.login.dto.response.LoginResponse;
 import com.keunsori.keunsoriserver.domain.auth.redis.RefreshTokenService;
+import com.keunsori.keunsoriserver.domain.auth.service.TokenService;
 import com.keunsori.keunsoriserver.domain.member.domain.Member;
 import com.keunsori.keunsoriserver.domain.member.repository.MemberRepository;
 import com.keunsori.keunsoriserver.global.exception.AuthException;
@@ -21,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LoginService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtTokenManager jwtTokenManager;
+    private final TokenService tokenService;
     private final RefreshTokenService refreshTokenService;
     private final JwtProperties jwtProperties;
 
@@ -38,11 +39,11 @@ public class LoginService {
         }
 
         //Access Token, Refresh Token 생성
-        String accessToken= jwtTokenManager.generateAccessToken(
+        String accessToken= tokenService.generateAccessToken(
                 member.getStudentId(), member.getName(), member.getStatus()
         );
 
-        String refreshToken= jwtTokenManager.generateRefreshToken(
+        String refreshToken= tokenService.generateRefreshToken(
                 member.getStudentId(), member.getName(), member.getStatus()
         );
 
@@ -52,7 +53,7 @@ public class LoginService {
         return new LoginResponse(
                 accessToken,
                 refreshToken,
-                String.valueOf(jwtTokenManager.getExpirationTime(accessToken)),
+                String.valueOf(tokenService.getExpirationTime(accessToken)),
                 member.getName(),
                 member.getStatus()
         );

--- a/src/main/java/com/keunsori/keunsoriserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/auth/service/AuthService.java
@@ -1,0 +1,72 @@
+package com.keunsori.keunsoriserver.domain.auth.service;
+
+import com.keunsori.keunsoriserver.domain.auth.redis.RefreshTokenService;
+import com.keunsori.keunsoriserver.domain.member.domain.Member;
+import com.keunsori.keunsoriserver.domain.member.repository.MemberRepository;
+import com.keunsori.keunsoriserver.global.exception.AuthException;
+import com.keunsori.keunsoriserver.global.exception.MemberException;
+import com.keunsori.keunsoriserver.global.properties.JwtProperties;
+import com.keunsori.keunsoriserver.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.*;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void login(Member member, HttpServletResponse response){
+
+        String accessToken=tokenService.generateAccessToken(member.getStudentId(), member.getName(),member.getStatus());
+        String refreshToken=tokenService.generateRefreshToken(member.getStudentId(), member.getName(),member.getStatus());
+
+        refreshTokenService.saveRefreshToken(member.getStudentId(),refreshToken, JwtProperties.REFRESH_TOKEN_VALIDITY_TIME);
+
+        CookieUtil.addAccessTokenCookie(response, accessToken);
+        CookieUtil.addRefreshTokenCookie(response, refreshToken);
+
+    }
+
+    @Transactional
+    public void reissueToken(String refreshToken, HttpServletResponse response){
+
+        if(refreshToken == null){
+            throw new AuthException(INVALID_REFRESH_TOKEN);
+        }
+
+        String studentId = tokenService.getStudentIdFromToken(refreshToken);
+        String storedRefreshToken = refreshTokenService.getRefreshToken(studentId);
+
+        if(storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
+            throw new AuthException(INVALID_REFRESH_TOKEN);
+        }
+
+        Member member = memberRepository.findByStudentIdIgnoreCase(studentId)
+                .orElseThrow(() -> new MemberException(STUDENT_ID_NOT_EXISTS));
+
+        String newAccessToken = tokenService.generateAccessToken(member.getStudentId(), member.getName(), member.getStatus());
+        CookieUtil.addAccessTokenCookie(response, newAccessToken);
+
+    }
+
+    @Transactional
+    public void logout(String refreshToken, HttpServletResponse response){
+
+        if(refreshToken != null){
+            String studentId = tokenService.getStudentIdFromToken(refreshToken);
+            refreshTokenService.deleteRefreshToken(studentId);
+        }
+
+        CookieUtil.deleteCookie(response, "Acccess-Token");
+        CookieUtil.deleteCookie(response, "Refresh-Token");
+    }
+
+}

--- a/src/main/java/com/keunsori/keunsoriserver/domain/auth/service/TokenService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/auth/service/TokenService.java
@@ -16,7 +16,6 @@ import java.util.Date;
 public class TokenService {
 
     private final JwtProperties jwtProperties;
-    private final RefreshTokenService refreshTokenService;
 
     // Access Token 생성
     public String generateAccessToken(String studentId, String name, MemberStatus status) {
@@ -25,9 +24,7 @@ public class TokenService {
 
     // Refresh Token 생성 (Redis에 저장 포함)
     public String generateRefreshToken(String studentId, String name, MemberStatus status) {
-        String refreshToken = createToken(studentId, name, status, jwtProperties.REFRESH_TOKEN_VALIDITY_TIME);
-        refreshTokenService.saveRefreshToken(studentId, refreshToken, jwtProperties.REFRESH_TOKEN_VALIDITY_TIME);
-        return refreshToken;
+      return createToken(studentId, name, status, jwtProperties.REFRESH_TOKEN_VALIDITY_TIME);
     }
 
     // JWT 토큰 생성 로직
@@ -89,21 +86,6 @@ public class TokenService {
                 .getBody()
                 .getExpiration()
                 .getTime();
-    }
-
-    // Refresh Token 삭제 (로그아웃 시 사용)
-    public void removeRefreshToken(String studentId) {
-        refreshTokenService.deleteRefreshToken(studentId);
-    }
-
-    // JWT 인증 헤더 반환
-    public String getHeader() {
-        return jwtProperties.HEADER;
-    }
-
-    // JWT Prefix 반환
-    public String getPrefix() {
-        return jwtProperties.PREFIX;
     }
 
     // Bearer 접두어 제거

--- a/src/main/java/com/keunsori/keunsoriserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/config/SecurityConfig.java
@@ -83,8 +83,7 @@ public class SecurityConfig  {
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
-//        configuration.addExposedHeader(SET_COOKIE);
-        configuration.addExposedHeader("Refresh-Token");
+        configuration.addExposedHeader("Set_Cookie");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/keunsori/keunsoriserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/exception/ErrorMessage.java
@@ -27,7 +27,7 @@ public class ErrorMessage {
     // Auth
     public static final String STUDENT_ID_NOT_EXISTS = "존재하지 않는 학번입니다.";
     public static final String PASSWORD_NOT_CORRECT = "비밀번호가 일치하지 않습니다.";
-    public static final String INVALID_REFRESH_TOKEN = "유효하지 않은 리프레시 토큰입니다.";
+    public static final String INVALID_REFRESH_TOKEN = "유효하지 않은 Refresh-token 입니다.";
 
     // Email
     public static final String EMAIL_NOT_EXISTS_FOR_AUTH = "인증번호를 전송하지 않았거나 인증번호가 만료되었습니다.";

--- a/src/main/java/com/keunsori/keunsoriserver/global/util/CookieUtil.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/util/CookieUtil.java
@@ -1,0 +1,50 @@
+package com.keunsori.keunsoriserver.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    private static final int ACCESS_TOKEN_EXPIRY=30*60;
+    private static final int REFRESH_TOKEN_EXPIRY=7*24*60*60;
+
+    public static void addAccessTokenCookie(HttpServletResponse response, String accessToken){
+        addCookie(response, "Access-Token", accessToken, ACCESS_TOKEN_EXPIRY);
+    }
+
+    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken){
+        addCookie(response, "Refresh-Token", refreshToken, REFRESH_TOKEN_EXPIRY);
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge){
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletResponse response, String name){
+        Cookie cookie = new Cookie(name, "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
+    public static String getCookieValue(HttpServletRequest request, String name){
+        if(request.getCookies() == null){
+            return null;
+        }
+
+        for(Cookie cookie : request.getCookies()){
+            if(cookie.getName().equals(name)){
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- jwtTokenManager 삭제
- authservice, tokenservice 추가
- securityconfig 수정
- jwtauthenticationfilter 수정

## 특이 사항 (리뷰 시 참고할 내용)
- http only cookie 방식 공부하면서 하느라 수정할 부분 좀 있을 수 있습니다..!

### 관련 이슈
close #72 
