### PR TITLE
refactor: 비밀번호 변경 검증 순서 조정

### DIFF
--- a/src/main/java/com/keunsori/keunsoriserver/domain/auth/login/dto/request/LoginRequest.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/auth/login/dto/request/LoginRequest.java
@@ -2,6 +2,7 @@ package com.keunsori.keunsoriserver.domain.auth.login.dto.request;
 
 import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.PASSWORD_REGEX;
 import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.STUDENT_ID_REGEX;
+import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.PASSWORD_INVALID_FORMAT;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -18,7 +19,7 @@ public record LoginRequest(
         @NotBlank(message = "비밀번호를 입력해주세요.")
         @Pattern(
                 regexp = PASSWORD_REGEX,
-                message = "비밀번호는 특수문자, 영문자, 숫자를 포함한 8자리 이상 문자열입니다."
+                message = PASSWORD_INVALID_FORMAT
         )
         String password
 ) {}

--- a/src/main/java/com/keunsori/keunsoriserver/domain/member/dto/request/MemberPasswordUpdateRequest.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/member/dto/request/MemberPasswordUpdateRequest.java
@@ -4,11 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.PASSWORD_REGEX;
+import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.PASSWORD_INVALID_FORMAT;
 
 public record MemberPasswordUpdateRequest(
         @NotBlank(message = "기존 비밀번호를 입력해주세요.")
         String currentPassword,
         @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_INVALID_FORMAT)
         String newPassword,
         @NotBlank(message = "새 비밀번호를 확인을 입력해주세요.")
         String passwordConfirm

--- a/src/main/java/com/keunsori/keunsoriserver/domain/member/dto/request/MemberPasswordUpdateRequest.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/member/dto/request/MemberPasswordUpdateRequest.java
@@ -7,10 +7,8 @@ import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.
 
 public record MemberPasswordUpdateRequest(
         @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-        @Pattern(regexp = PASSWORD_REGEX, message = "비밀번호는 특수문자, 영문자, 숫자를 포함한 8자리 이상 문자열입니다.")
         String currentPassword,
         @NotBlank(message = "새 비밀번호를 입력해주세요.")
-        @Pattern(regexp = PASSWORD_REGEX, message = "비밀번호는 특수문자, 영문자, 숫자를 포함한 8자리 이상 문자열입니다.")
         String newPassword,
         @NotBlank(message = "새 비밀번호를 확인을 입력해주세요.")
         String passwordConfirm

--- a/src/main/java/com/keunsori/keunsoriserver/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/member/dto/request/SignUpRequest.java
@@ -2,6 +2,7 @@ package com.keunsori.keunsoriserver.domain.member.dto.request;
 
 import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.PASSWORD_REGEX;
 import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.STUDENT_ID_REGEX;
+import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.PASSWORD_INVALID_FORMAT;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -22,7 +23,7 @@ public record SignUpRequest(
         String email,
 
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-        @Pattern(regexp = PASSWORD_REGEX, message = "비밀번호는 특수문자, 영문자, 숫자를 포함한 8자리 이상 문자열입니다.")
+        @Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_INVALID_FORMAT)
         String password,
 
         @NotBlank(message = "비밀번호를 한 번 더 입력해주세요.")

--- a/src/main/java/com/keunsori/keunsoriserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/member/service/MemberService.java
@@ -43,13 +43,6 @@ public class MemberService {
             throw new AuthException(PASSWORD_NOT_CORRECT);
         }
 
-        // 새 비밀번호 패턴 검증
-        Pattern pattern = Pattern.compile(PASSWORD_REGEX);
-        Matcher matcher = pattern.matcher(request.newPassword());
-        if(!matcher.matches()){
-            throw new MemberException(PASSWORD_INVALID_FORMAT);
-        }
-
         // 새 비밀번호 확인 일치 검증
         if(!request.newPassword().equals(request.passwordConfirm())) {
             throw new MemberException(PASSWORD_IS_DIFFERENT_FROM_CHECK);

--- a/src/main/java/com/keunsori/keunsoriserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/keunsori/keunsoriserver/domain/member/service/MemberService.java
@@ -13,6 +13,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.keunsori.keunsoriserver.global.constant.RequestFormatConstant.PASSWORD_REGEX;
 import static com.keunsori.keunsoriserver.global.exception.ErrorMessage.*;
 
 @Service
@@ -34,10 +38,19 @@ public class MemberService {
     public void updatePassword(MemberPasswordUpdateRequest request) {
         Member member = memberUtil.getLoggedInMember();
 
+        // 현재 비밀번호 일치 검증
         if(!passwordEncoder.matches(request.currentPassword(), member.getPassword())){
             throw new AuthException(PASSWORD_NOT_CORRECT);
         }
 
+        // 새 비밀번호 패턴 검증
+        Pattern pattern = Pattern.compile(PASSWORD_REGEX);
+        Matcher matcher = pattern.matcher(request.newPassword());
+        if(!matcher.matches()){
+            throw new MemberException(PASSWORD_INVALID_FORMAT);
+        }
+
+        // 새 비밀번호 확인 일치 검증
         if(!request.newPassword().equals(request.passwordConfirm())) {
             throw new MemberException(PASSWORD_IS_DIFFERENT_FROM_CHECK);
         }

--- a/src/main/java/com/keunsori/keunsoriserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/exception/ErrorMessage.java
@@ -6,6 +6,7 @@ public class ErrorMessage {
     public static final String DUPLICATED_STUDENT_ID = "이미 존재하는 학번입니다.";
     public static final String DUPLICATED_EMAIL = "이미 존재하는 이메일입니다.";
     public static final String PASSWORD_IS_DIFFERENT_FROM_CHECK = "비밀번호와 비밀번호 확인 입력값이 다릅니다.";
+    public static final String PASSWORD_INVALID_FORMAT = "비밀번호는 특수문자, 영문자, 숫자를 포함한 8자리 이상 문자열입니다.";
 
     // Admin Member
     public static final String INVALID_STATUS_FOR_APPROVAL = "회원이 승인 대기 상태가 아닙니다.";

--- a/src/test/java/com/keunsori/keunsoriserver/member/api/MemberApiTest.java
+++ b/src/test/java/com/keunsori/keunsoriserver/member/api/MemberApiTest.java
@@ -160,4 +160,42 @@ public class MemberApiTest extends ApiTest {
 
         Assertions.assertThat(errorMessage).isEqualTo(PASSWORD_IS_DIFFERENT_FROM_CHECK);
     }
+
+    @Test
+    void 현재_비밀번호_틀리고_새_비밀번호_패턴_안맞을때_현재_비밀번호_틀림_에러로_뜬다() throws JsonProcessingException {
+        MemberPasswordUpdateRequest request = new MemberPasswordUpdateRequest("test123#",
+                "password", "password");
+
+        String errorMessage = given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request)).
+                when().
+                patch("/members/me/password").
+                then().
+                statusCode(HttpStatus.SC_UNAUTHORIZED).
+                extract().
+                jsonPath().get("message");
+
+        Assertions.assertThat(errorMessage).isEqualTo(PASSWORD_NOT_CORRECT);
+    }
+
+    @Test
+    void 새_비밀번호_패턴_안맞고_비밀번호_확인_틀릴때_패턴_안맞음_에러로_뜬다() throws JsonProcessingException {
+        MemberPasswordUpdateRequest request = new MemberPasswordUpdateRequest("test123!",
+                "password", "password1");
+
+        String errorMessage = given().
+                header(AUTHORIZATION, authorizationValue).
+                header(CONTENT_TYPE, "application/json").
+                body(mapper.writeValueAsString(request)).
+                when().
+                patch("/members/me/password").
+                then().
+                statusCode(HttpStatus.SC_BAD_REQUEST).
+                extract().
+                jsonPath().get("message");
+
+        Assertions.assertThat(errorMessage).isEqualTo(PASSWORD_INVALID_FORMAT);
+    }
 }

--- a/src/test/java/com/keunsori/keunsoriserver/member/api/MemberApiTest.java
+++ b/src/test/java/com/keunsori/keunsoriserver/member/api/MemberApiTest.java
@@ -162,25 +162,6 @@ public class MemberApiTest extends ApiTest {
     }
 
     @Test
-    void 현재_비밀번호_틀리고_새_비밀번호_패턴_안맞을때_현재_비밀번호_틀림_에러로_뜬다() throws JsonProcessingException {
-        MemberPasswordUpdateRequest request = new MemberPasswordUpdateRequest("test123#",
-                "password", "password");
-
-        String errorMessage = given().
-                header(AUTHORIZATION, authorizationValue).
-                header(CONTENT_TYPE, "application/json").
-                body(mapper.writeValueAsString(request)).
-                when().
-                patch("/members/me/password").
-                then().
-                statusCode(HttpStatus.SC_UNAUTHORIZED).
-                extract().
-                jsonPath().get("message");
-
-        Assertions.assertThat(errorMessage).isEqualTo(PASSWORD_NOT_CORRECT);
-    }
-
-    @Test
     void 새_비밀번호_패턴_안맞고_비밀번호_확인_틀릴때_패턴_안맞음_에러로_뜬다() throws JsonProcessingException {
         MemberPasswordUpdateRequest request = new MemberPasswordUpdateRequest("test123!",
                 "password", "password1");


### PR DESCRIPTION
## 작업 내용
- 기존에 Pattern 가장 먼저 적용, 기존 비밀번호, 비밀번호 확인 검증 순으로 검증이 됐는데
1. 현재 비밀번호 확인
2. 새 비밀번호 패턴 확인
3. 비밀번호 확인 검증
순으로 바꿨습니다.
- 기존 비밀번호에는 패턴을 적용 안 하는게 나을 것 같아 뺐습니다!

## 특이 사항 (리뷰 시 참고할 내용)
- 

### 관련 이슈
close #90 
