### PR TITLE
chore: 시큐리티 필터 url 수정및 리프레시 토큰 값 일정 문제 해결

### DIFF
--- a/src/main/java/com/keunsori/keunsoriserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/config/SecurityConfig.java
@@ -44,8 +44,11 @@ public class SecurityConfig  {
                .authorizeHttpRequests(auth -> auth
                        // 인증 없이 로그인,회원가입은 가능.
                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                       .requestMatchers("/auth/**", "/email/**").permitAll()
+                       .requestMatchers("/auth/login", "/email/**").permitAll()
                        .requestMatchers("/signup").permitAll()
+
+                       // 로그아웃은 로그인 이후 가능
+                       .requestMatchers("members/me/logout").hasAnyAuthority("일반", "관리자")
 
                        // 회원 관련된 건 일반 권한 필요
                        .requestMatchers("/members/**").hasAuthority("일반")

--- a/src/main/java/com/keunsori/keunsoriserver/global/util/TokenUtil.java
+++ b/src/main/java/com/keunsori/keunsoriserver/global/util/TokenUtil.java
@@ -1,7 +1,6 @@
 package com.keunsori.keunsoriserver.global.util;
 
 import com.keunsori.keunsoriserver.domain.member.domain.vo.MemberStatus;
-import com.keunsori.keunsoriserver.global.constant.TokenConstant;
 import com.keunsori.keunsoriserver.global.exception.AuthException;
 import com.keunsori.keunsoriserver.global.properties.JwtProperties;
 import io.jsonwebtoken.Claims;
@@ -9,7 +8,6 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;


### PR DESCRIPTION
## 작업 내용
- auth 관련 요청 모두 허용하는 대신 로그인만 가능하도록 url 주소 변경했습니다.
- url 수정하면서 Filter에 refresh token 값이 일정했던 문제까지 같이 해결했습니다 

## 특이 사항 (리뷰 시 참고할 내용)
- 

### 관련 이슈
close #21 , #37 
