### PR TITLE
fix: 도커파일 자바 이미지 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:21
+FROM eclipse-temurin:21-jre
 COPY build/libs/*.jar /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
## 작업 내용
- 도커파일 자바 이미지 변경 openjdk:21  ->  eclipse-temurin:21-jre

## 특이 사항 (리뷰 시 참고할 내용)
- 

### 관련 이슈
close #164 
