### PR TITLE
chore: postgresql 데이터베이스 이전

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB
-    implementation 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,5 +1,5 @@
 spring:
   datasource:
-    url: "jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT:3306}/${DATABASE_NAME}"
+    url: "jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT:5432}/${DATABASE_NAME}?sslmode=require"
     username: "${DATABASE_USERNAME}"
     password: "${DATABASE_PASSWORD}"


### PR DESCRIPTION
## 작업 내용
- jdbc url 설정 및 드라이버 의존성 변경

## 특이 사항 (리뷰 시 참고할 내용)
- 데이터베이스로는 supabase 기반의 postgresql 을 사용할 예정입니다. 접속 정보는 노션에 추가해두겠습니다.
- 로컬에서 supabase 접속 및 실행 테스트 하였습니다.
- 테스트는 여전히 MySQL 모드로 실행중인데, 찾아보니 Postgresql 버전으로 실행하려면 테스트 컨테이너를 별도로 띄워야 하는 것 같습니다. 별도 이슈에서 해결하도록 하겠습니다.

### 관련 이슈
close #168 
